### PR TITLE
Issue #5: Use method on the user account object to determine its ID.

### DIFF
--- a/user_cancel_password_confirm.module
+++ b/user_cancel_password_confirm.module
@@ -55,13 +55,13 @@ function user_cancel_password_confirm_submit($form, &$form_state) {
 
   // Cancel the account directly and redirect to the front page.
   $account = $form_state['values']['_account'];
-  user_cancel($form_state['values'], $account->uid, $form_state['values']['user_cancel_method']);
+  user_cancel($form_state['values'], $account->id(), $form_state['values']['user_cancel_method']);
   $form_state['redirect'] = '<front>';
 
   // Display a message to users who are cancelling their own accounts
   // (administrators cancelling another user's account will already get a
   // standard message).
-  $cancel_own_account = $account->uid == $user->uid;
+  $cancel_own_account = $account->id() == $user->uid;
   if ($cancel_own_account) {
     backdrop_set_message(t('Your account has been canceled.'));
   }


### PR DESCRIPTION
Fixes https://github.com/DavidRothstein/user_cancel_password_confirm/issues/5
